### PR TITLE
v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fast-crc32c",
+  "name": "@chainsafe/fast-crc32c",
   "description": "CRC32C algorithm with hardware acceleration and software fallback.",
   "version": "4.0.0",
   "author": "Xiaoyi Shi <ashi009@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "fast-crc32c",
   "description": "CRC32C algorithm with hardware acceleration and software fallback.",
-  "version": "2.0.0",
+  "version": "4.0.0",
   "author": "Xiaoyi Shi <ashi009@gmail.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ashi009/node-fast-crc32c.git"
+    "url": "git@github.com:ChainSafe/node-fast-crc32c.git"
   },
   "main": "./loader",
   "optionalDependencies": {


### PR DESCRIPTION
**Motivation**
- To prepare for the next release

**Description**
- I'm not sure why npm already have version 3.0.0 (see https://www.npmjs.com/package/@chainsafe/fast-crc32c) so I updated to v4.0.0